### PR TITLE
Generate legacy suppliers

### DIFF
--- a/config-0.14.xsd
+++ b/config-0.14.xsd
@@ -59,6 +59,14 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="generateLegacySuppliers" minOccurs="0" type="xs:boolean">
+        <xs:annotation>
+          <xs:documentation source="version">0.14+</xs:documentation>
+          <xs:documentation source="description">
+            Whether generated methods should return suppliers or values.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="options">
         <xs:annotation>
           <xs:documentation source="version">0.1+</xs:documentation>

--- a/config-current.xsd
+++ b/config-current.xsd
@@ -1,1 +1,1 @@
-config-0.13.xsd
+config-0.14.xsd


### PR DESCRIPTION
This adds the `generateLegacySuppliers` and updates `config-current.xsd` to version 0.14 now that all of my changes have been merged.

@jhaber @kmclarnon